### PR TITLE
Update MPAA rating filter

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -13,7 +13,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
+"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #empty strings from id 32000 to 32009
@@ -65,7 +65,7 @@ msgid "None of your movies has a MPAA rating, so the [I]Limit movie selection ba
 msgstr ""
 
 msgctxt "#32021"
-msgid "None of your movies has a Content rating, so the [I]Limit TV show selection based on Content rating[/I] setting will be disabled."
+msgid "None of your TV shows has a Content rating, so the [I]Limit TV show selection based on Content rating[/I] setting will be disabled."
 msgstr ""
 
 #empty strings from id 32022 to 32099
@@ -303,7 +303,7 @@ msgid "Limit movie selection based on MPAA rating"
 msgstr ""
 
 msgctxt "#32505"
-msgid "Max. MPAA rating"
+msgid "MPAA ratings to include"
 msgstr ""
 
 msgctxt "#32506"
@@ -319,7 +319,7 @@ msgid "Limit TV show selection based on Content rating"
 msgstr ""
 
 msgctxt "#32509"
-msgid "Max. Content rating"
+msgid "Content ratings to include"
 msgstr ""
 
 #empty strings from id 32510 to 32549

--- a/resources/lib/quizlib/gui.py
+++ b/resources/lib/quizlib/gui.py
@@ -43,10 +43,6 @@ BACKGROUND_TV = os.path.join(RESOURCES_PATH, 'skins', 'Default', 'media', 'quiz-
 BACKGROUND_THEME = os.path.join(RESOURCES_PATH, 'skins', 'Default', 'media', 'quiz-background-theme.jpg')
 NO_PHOTO_IMAGE = os.path.join(RESOURCES_PATH, 'skins', 'Default', 'media', 'quiz-no-photo.png')
 
-MPAA_RATINGS = ['R', 'Rated R', 'PG-13', 'Rated PG-13', 'PG', 'Rated PG', 'G', 'Rated G']
-CONTENT_RATINGS = ['TV-MA', 'TV-14', 'TV-PG', 'TV-G', 'TV-Y7-FV', 'TV-Y7', 'TV-Y']
-
-
 class MenuGui(xbmcgui.WindowXMLDialog):
     C_MENU_LIST = 4001
     C_INFO_TEXT = 6001
@@ -292,13 +288,10 @@ class QuizGui(xbmcgui.WindowXML):
 
         self.defaultLibraryFilters = list()
         if gameInstance.getType() == game.GAMETYPE_MOVIE and ADDON.getSetting('movie.rating.limit.enabled') == 'true':
-            idx = MPAA_RATINGS.index(ADDON.getSetting('movie.rating.limit'))
-            self.defaultLibraryFilters.extend(iter(library.buildRatingsFilters('mpaarating', MPAA_RATINGS[:idx])))
+            self.defaultLibraryFilters.extend(library.buildRatingsFilters(ADDON.getSetting('movie.rating.limit')))
 
-        elif gameInstance.getType() == game.GAMETYPE_TVSHOW and ADDON.getSetting(
-                'tvshow.rating.limit.enabled') == 'true':
-            idx = CONTENT_RATINGS.index(ADDON.getSetting('tvshow.rating.limit'))
-            self.defaultLibraryFilters.extend(iter(library.buildRatingsFilters('rating', CONTENT_RATINGS[:idx])))
+        elif gameInstance.getType() == game.GAMETYPE_TVSHOW and ADDON.getSetting('tvshow.rating.limit.enabled') == 'true':
+            self.defaultLibraryFilters.extend(library.buildRatingsFilters(ADDON.getSetting('tvshow.rating.limit')))
 
         if ADDON.getSetting(SETT_ONLY_WATCHED_MOVIES) == 'true':
             self.defaultLibraryFilters.extend(library.buildOnlyWatchedFilter())

--- a/resources/lib/quizlib/library.py
+++ b/resources/lib/quizlib/library.py
@@ -154,7 +154,7 @@ def buildRatingsFilters(ratings):
                 'value': ratingAlias
             })
 
-    logger.debug(f"filters: {filters}")
+    logger.debug(f"ratings filters: {filters}")
     return [{
         'or': filters
     }]
@@ -189,7 +189,7 @@ class Query:
             self.query['params'] = self.params
 
         command = json.dumps(self.query)
-        logger.debug(f'jsonrpc command: {command}')
+        logger.debug(f'jsonrpc request: {command}')
         resp = xbmc.executeJSONRPC(command)
         logger.debug(f'jsonrpc response: {resp}')
         return json.loads(resp)

--- a/resources/lib/quizlib/logger.py
+++ b/resources/lib/quizlib/logger.py
@@ -1,4 +1,21 @@
 import xbmc
 
+LOG_PREFACE = "script.moviequiz >> "
+
 def log(message, level=xbmc.LOGDEBUG):
-    xbmc.log("script.moviequiz >> " + message, level)
+    xbmc.log(LOG_PREFACE + message, level)
+
+def debug(message):
+    xbmc.log(LOG_PREFACE + message, xbmc.LOGDEBUG)
+
+def info(message):
+    xbmc.log(LOG_PREFACE + message, xbmc.LOGINFO)
+
+def warning(message):
+    xbmc.log(LOG_PREFACE + message, xbmc.LOGWARNING)
+
+def error(message):
+    xbmc.log(LOG_PREFACE + message, xbmc.LOGERROR)
+
+def fatal(message):
+    xbmc.log(LOG_PREFACE + message, xbmc.LOGFATAL)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -21,30 +21,35 @@
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
-                <setting id="movie.rating.limit" label="32505" type="string" parent="movie.rating.limit.enabled">
+                <setting id="movie.rating.limit" label="32505" type="list[string]" parent="movie.rating.limit.enabled">
                     <level>0</level>
-                    <default>R</default>
+                    <default>G|PG|PG-13</default>
                     <constraints>
                         <options>
                             <option label="G">G</option>
                             <option label="PG">PG</option>
                             <option label="PG-13">PG-13</option>
                             <option label="R">R</option>
+                            <option label="NR">NR</option>
+                            <option label="No rating (empty)">empty</option>
                         </options>
                     </constraints>
                     <dependencies>
                         <dependency type="enable" setting="movie.rating.limit.enabled">true</dependency>
                     </dependencies>
-                    <control type="spinner" format="string"/>
+                    <control type="list" format="string">
+                        <multiselect>true</multiselect>
+                        <hidevalue>false</hidevalue>
+                    </control>
                 </setting>
                 <setting id="tvshow.rating.limit.enabled" label="32508" type="boolean">
                     <level>0</level>
                     <default>false</default>
                     <control type="toggle"/>
                 </setting>
-                <setting id="tvshow.rating.limit" label="32509" type="string" parent="tvshow.rating.limit.enabled">
+                <setting id="tvshow.rating.limit" label="32509" type="list[string]" parent="tvshow.rating.limit.enabled">
                     <level>0</level>
-                    <default>TV-MA</default>
+                    <default>TV-Y|TV-Y7|TV-Y7-FV|TV-G|TV-PG|TV-14</default>
                     <constraints>
                         <options>
                             <option label="TV-Y">TV-Y</option>
@@ -54,12 +59,16 @@
                             <option label="TV-PG">TV-PG</option>
                             <option label="TV-14">TV-14</option>
                             <option label="TV-MA">TV-MA</option>
+                            <option label="No rating (empty)">empty</option>
                         </options>
                     </constraints>
                     <dependencies>
                         <dependency type="enable" setting="tvshow.rating.limit.enabled">true</dependency>
                     </dependencies>
-                    <control type="spinner" format="string"/>
+                    <control type="list" format="string">
+                        <multiselect>true</multiselect>
+                        <hidevalue>false</hidevalue>
+                    </control>
                 </setting>
             </group>
         </category>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,7 +31,7 @@
                             <option label="PG-13">PG-13</option>
                             <option label="R">R</option>
                             <option label="NR">NR</option>
-                            <option label="No rating (empty)">empty</option>
+                            <option label="None (rating not available)">none</option>
                         </options>
                     </constraints>
                     <dependencies>
@@ -49,17 +49,17 @@
                 </setting>
                 <setting id="tvshow.rating.limit" label="32509" type="list[string]" parent="tvshow.rating.limit.enabled">
                     <level>0</level>
-                    <default>TV-Y|TV-Y7|TV-Y7-FV|TV-G|TV-PG|TV-14</default>
+                    <default>TV-Y|TV-Y7|TV-G|TV-PG|TV-14</default>
                     <constraints>
                         <options>
                             <option label="TV-Y">TV-Y</option>
                             <option label="TV-Y7">TV-Y7</option>
-                            <option label="TV-Y7-FV">TV-Y7-FV</option>
                             <option label="TV-G">TV-G</option>
                             <option label="TV-PG">TV-PG</option>
                             <option label="TV-14">TV-14</option>
                             <option label="TV-MA">TV-MA</option>
-                            <option label="No rating (empty)">empty</option>
+                            <option label="NR">NR</option>
+                            <option label="None (rating not available)">none</option>
                         </options>
                     </constraints>
                     <dependencies>


### PR DESCRIPTION
Update the MPAA rating filter.

The filter option in the settings menu is now a multi-select so the user can select movies/tv shows with specific ratings they want to include in the quiz.
