### PR TITLE
Fix for Python 3.11

### DIFF
--- a/resources/lib/quizlib/question.py
+++ b/resources/lib/quizlib/question.py
@@ -37,7 +37,7 @@ class VideoDisplayType(DisplayType):
     def setVideoFile(self, videoFile):
         self.videoFile = videoFile
         if not xbmcvfs.exists(self.videoFile):
-            raise QuestionException(f'Video file not found: {self.videoFile.encode('utf-8', 'ignore')}')
+            raise QuestionException(f"Video file not found: {self.videoFile.encode('utf-8', 'ignore')}")
 
     def getVideoFile(self):
         return self.videoFile


### PR DESCRIPTION
When running on Python 3.11, the plugin fail to start with:

```
2025-12-07 12:15:12.103 T:996423   error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'SyntaxError'>
                                                   Error Contents: f-string: unmatched '(' (question.py, line 40)
                                                   Traceback (most recent call last):
                                                     File "/home/romain/.kodi/addons/script.moviequiz/addon.py", line 26, in <module>
                                                       from resources.lib.quizlib.gui import QuizGui
                                                     File "/home/romain/.kodi/addons/script.moviequiz/resources/lib/quizlib/gui.py", line 25, in <module>
                                                       from . import game, imdb, question, library, player
                                                     File "/home/romain/.kodi/addons/script.moviequiz/resources/lib/quizlib/question.py", line 40
                                                       raise QuestionException(f'Video file not found: {self.videoFile.encode('utf-8', 'ignore')}')
                                                                                                                               ^^^
                                                   SyntaxError: f-string: unmatched '('
                                                   -->End of Python script error report<--
```

Support for quote reuse in f-strings was only added in Python 3.12:

> Quote reuse: in Python 3.11, reusing the same quotes as the enclosing
> f-string raises a SyntaxError, forcing the user to either use other
> available quotes (like using double quotes or triple quotes if the
> f-string uses single quotes).

PEP 701: https://peps.python.org/pep-0701/

Avoid this error by using different quotes.
